### PR TITLE
Add microdata parsing and alignment update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # AuditCrawler
-A crawler designed to test structured web deployments basic qualifiers.
+A crawler designed to test structured web deployments basic qualifiers. The auditor extracts JSON-LD and microdata to evaluate semantic alignment.

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ Each page undergoes **5 integrated modules**:
 
 ### 2. Schema Audit  
 - Confirms valid JSON-LD presence.  
-- Parses microdata when available.  
+ - Parses microdata when available using `itemtype`/`itemprop` attributes.
 - Validates JSON structure for `.json` endpoints.  
 - Flags missing or invalid markup.
 
@@ -78,7 +78,8 @@ Each page undergoes **5 integrated modules**:
 ### 5. Semantic Alignment Audit  
 - Extracts keywords from visible text.  
 - Compares to extracted descriptions and keyword arrays in JSON-LD & microdata.  
-- Calculates a raw alignment score — % of structured keywords found in actual page content.  
+- Calculates a raw alignment score — % of structured keywords found in actual page content.
+- Structured keywords now include both JSON-LD and microdata terms.
 - Reports missing keywords to guide realignment.
 
 ---

--- a/semantic_alignment.py
+++ b/semantic_alignment.py
@@ -69,16 +69,16 @@ def audit_semantic_alignment(
     json_keywords = set(extract_json_ld_keywords(json_ld_blocks))
     micro_keywords = set(extract_microdata_keywords(microdata_items))
 
-    shared = json_keywords.intersection(html_keywords)
-    all_keywords = json_keywords.union(html_keywords)
+    sd_keywords = json_keywords.union(micro_keywords)
+    shared = sd_keywords.intersection(html_keywords)
 
     alignment_percent = (
-        round(len(shared) / len(json_keywords) * 100, 2) if json_keywords else 0
+        round(len(shared) / len(sd_keywords) * 100, 2) if sd_keywords else 0
     )
 
     return {
         "alignment_percent": alignment_percent,
         "shared_terms": sorted(list(shared)),
-        "missing_terms": sorted(list(json_keywords - html_keywords)),
-        "total_sd_terms": len(json_keywords)
+        "missing_terms": sorted(list(sd_keywords - html_keywords)),
+        "total_sd_terms": len(sd_keywords)
     }


### PR DESCRIPTION
## Summary
- parse microdata in `schema` using BeautifulSoup
- record new `has_microdata` and `microdata_data` fields
- include microdata keywords when computing semantic alignment
- document microdata extraction and alignment changes in README files

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68674f5499ec832db0cbf4f8ab06a66f